### PR TITLE
Implement Mars largest picture service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/nourish1709/largestmarspicture/LargestMarsPictureApplication.java
+++ b/src/main/java/com/nourish1709/largestmarspicture/LargestMarsPictureApplication.java
@@ -2,8 +2,10 @@ package com.nourish1709.largestmarspicture;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class LargestMarsPictureApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/nourish1709/largestmarspicture/config/BeanConfiguration.java
+++ b/src/main/java/com/nourish1709/largestmarspicture/config/BeanConfiguration.java
@@ -1,0 +1,20 @@
+package com.nourish1709.largestmarspicture.config;
+
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class BeanConfiguration {
+
+    @Bean
+    public RestTemplate redirectingRestTemplate() {
+        return new RestTemplate(new HttpComponentsClientHttpRequestFactory(
+                HttpClientBuilder.create()
+                        .setRedirectStrategy(new LaxRedirectStrategy())
+                        .build()));
+    }
+}

--- a/src/main/java/com/nourish1709/largestmarspicture/config/MarsApiParams.java
+++ b/src/main/java/com/nourish1709/largestmarspicture/config/MarsApiParams.java
@@ -1,0 +1,21 @@
+package com.nourish1709.largestmarspicture.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("mars.api")
+@Setter
+@Getter
+public class MarsApiParams {
+
+    private String url;
+    private String solKey;
+    private String apiKey;
+    private String apiValue;
+    private String cameraKey;
+    private String cameraDefaultValue;
+    private String imgKey;
+}

--- a/src/main/java/com/nourish1709/largestmarspicture/controller/LargestMarsPictureController.java
+++ b/src/main/java/com/nourish1709/largestmarspicture/controller/LargestMarsPictureController.java
@@ -3,15 +3,13 @@ package com.nourish1709.largestmarspicture.controller;
 import com.nourish1709.largestmarspicture.service.LargestMarsPictureService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.net.URI;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/mars/pictures")
@@ -20,16 +18,12 @@ public class LargestMarsPictureController {
 
     private final LargestMarsPictureService largestMarsPictureService;
 
-    @GetMapping("/largest")
-    public ResponseEntity<Void> getLargestPicture(@RequestParam int sol,
-                                                  @RequestParam(required = false) String camera) {
-        Optional<URI> largestPictureURL = largestMarsPictureService.getLargestPicture(sol, camera);
-        if (largestPictureURL.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                    "No pictures found for parameters: sol = %d, camera = %s".formatted(sol, camera));
-        }
-        return ResponseEntity.status(HttpStatus.PERMANENT_REDIRECT)
-                .location(largestPictureURL.get())
-                .build();
+    @GetMapping(value = "/largest", produces = MediaType.IMAGE_JPEG_VALUE)
+    public ResponseEntity<byte[]> getLargestPicture(@RequestParam int sol,
+                                                    @RequestParam(required = false) String camera) {
+        byte[] largestPicture = largestMarsPictureService.getLargestPicture(sol, camera)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "No pictures found for parameters: sol = %d, camera = %s".formatted(sol, camera)));
+        return ResponseEntity.ok(largestPicture);
     }
 }

--- a/src/main/java/com/nourish1709/largestmarspicture/controller/LargestMarsPictureController.java
+++ b/src/main/java/com/nourish1709/largestmarspicture/controller/LargestMarsPictureController.java
@@ -1,0 +1,35 @@
+package com.nourish1709.largestmarspicture.controller;
+
+import com.nourish1709.largestmarspicture.service.LargestMarsPictureService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.net.URI;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/mars/pictures")
+@RequiredArgsConstructor
+public class LargestMarsPictureController {
+
+    private final LargestMarsPictureService largestMarsPictureService;
+
+    @GetMapping("/largest")
+    public ResponseEntity<Void> getLargestPicture(@RequestParam int sol,
+                                                  @RequestParam(required = false) String camera) {
+        Optional<URI> largestPictureURL = largestMarsPictureService.getLargestPicture(sol, camera);
+        if (largestPictureURL.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "No pictures found for parameters: sol = %d, camera = %s".formatted(sol, camera));
+        }
+        return ResponseEntity.status(HttpStatus.PERMANENT_REDIRECT)
+                .location(largestPictureURL.get())
+                .build();
+    }
+}

--- a/src/main/java/com/nourish1709/largestmarspicture/service/LargestMarsPictureService.java
+++ b/src/main/java/com/nourish1709/largestmarspicture/service/LargestMarsPictureService.java
@@ -1,0 +1,11 @@
+package com.nourish1709.largestmarspicture.service;
+
+import org.springframework.lang.Nullable;
+
+import java.net.URI;
+import java.util.Optional;
+
+public interface LargestMarsPictureService {
+
+    Optional<URI> getLargestPicture(int sol, @Nullable String camera);
+}

--- a/src/main/java/com/nourish1709/largestmarspicture/service/LargestMarsPictureService.java
+++ b/src/main/java/com/nourish1709/largestmarspicture/service/LargestMarsPictureService.java
@@ -2,10 +2,9 @@ package com.nourish1709.largestmarspicture.service;
 
 import org.springframework.lang.Nullable;
 
-import java.net.URI;
 import java.util.Optional;
 
 public interface LargestMarsPictureService {
 
-    Optional<URI> getLargestPicture(int sol, @Nullable String camera);
+    Optional<byte[]> getLargestPicture(int sol, @Nullable String camera);
 }

--- a/src/main/java/com/nourish1709/largestmarspicture/service/SimpleLargestMarsPictureService.java
+++ b/src/main/java/com/nourish1709/largestmarspicture/service/SimpleLargestMarsPictureService.java
@@ -1,0 +1,51 @@
+package com.nourish1709.largestmarspicture.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.nourish1709.largestmarspicture.config.MarsApiParams;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Comparator;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+@Service
+@RequiredArgsConstructor
+public class SimpleLargestMarsPictureService implements LargestMarsPictureService {
+
+    private final RestTemplate restTemplate;
+    private final MarsApiParams marsApiParams;
+
+    @Override
+    @Cacheable("largestPicture")
+    public Optional<URI> getLargestPicture(int sol, String camera) {
+        if (camera == null || camera.isBlank())
+            camera = marsApiParams.getCameraDefaultValue();
+
+        final JsonNode rootNode = restTemplate.getForObject(UriComponentsBuilder.fromHttpUrl(marsApiParams.getUrl())
+                .queryParam(marsApiParams.getSolKey(), sol)
+                .queryParam(marsApiParams.getApiKey(), marsApiParams.getApiValue())
+                .queryParam(marsApiParams.getCameraKey(), camera)
+                .build().toUri(), JsonNode.class);
+
+        return requireNonNull(rootNode).findValues(marsApiParams.getImgKey()).stream()
+                .parallel()
+                .max(getContentLengthComparator())
+                .map(this::toUri);
+    }
+
+    private URI toUri(JsonNode jsonNode) {
+        return UriComponentsBuilder.fromHttpUrl(jsonNode.asText()).build().toUri();
+    }
+
+    private Comparator<JsonNode> getContentLengthComparator() {
+        return Comparator.comparingLong(node ->
+                restTemplate.headForHeaders(toUri(node))
+                        .getContentLength());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+mars:
+  api:
+    url: https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/photos
+    sol_key: sol
+    api_key: api_key
+    api_value: DEMO_KEY
+    camera_key: camera
+    camera_default_value: NAVCAM
+    img_key: img_src
+server:
+  error:
+    include-message: always


### PR DESCRIPTION
A feature that **redirects to the largest Mars picture**

Endpoint preview: 
`GET http://localhost:8080/mars/pictures/largest?sol=1000&camera=NAVCAM`

Request parameter `camera` is optional